### PR TITLE
Include TALM logs and CGUs in must-gather

### DIFF
--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -135,6 +135,10 @@ gather_hub() {
 
     oc adm inspect ns/openshift-monitoring  --dest-dir=must-gather
 
+    # Topology Aware Lifecycle Manager CRs
+    oc adm inspect ns/openshift-operators  --dest-dir=must-gather
+    oc adm inspect clustergroupupgrades.ran.openshift.io --all-namespaces  --dest-dir=must-gather
+
     # Inspect Assisted-installer CRs
     oc adm inspect agent.agent-install.openshift.io --all-namespaces --dest-dir=must-gather
     oc adm inspect agentclassification.agent-install.openshift.io --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
As part of ACM/TALM alignment (CNF-7366) ACM must-gather should include TALM logs and CGUs