### PR TITLE
ACM-6005 Fix MCE Naming Conventions

### DIFF
--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -14,9 +14,9 @@ OPERATOR_NAMESPACE=""
 DEPLOYMENT_NAMESPACE=""
 
 check_managed_clusters() {
-    echo "The list of managed clusters that are configured on this Hub:" >> ${BASE_COLLECTION_PATH}/gather-managed.log
+    echo "The list of managed clusters that are configured on this Hub:" >> ${BASE_COLLECTION_PATH}/gather-managed-mce.log
     #These calls will change with new API
-    oc get managedclusters --all-namespaces >> ${BASE_COLLECTION_PATH}/gather-managed.log
+    oc get managedclusters --all-namespaces >> ${BASE_COLLECTION_PATH}/gather-managed-mce.log
 
     #to capture details in the managed cluster namespace to debug hive issues
     #refer https://github.com/open-cluster-management/backlog/issues/2682
@@ -24,7 +24,7 @@ check_managed_clusters() {
 
     for mcns in ${mc_namespaces};
     do
-        #oc kubectl get pods -n "$mcns" >> ${BASE_COLLECTION_PATH}/gather-managed.log
+        #oc kubectl get pods -n "$mcns" >> ${BASE_COLLECTION_PATH}/gather-managed-mce.log
         oc adm inspect  ns/"$mcns"  --dest-dir=must-gather
     done
 }
@@ -80,14 +80,14 @@ gather_spoke () {
 
 gather_hub() {
     check_managed_clusters
-    oc get pods -n "${OPERATOR_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-acm.log
-    oc get pods -n "${DEPLOYMENT_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-acm.log
-    oc get csv -n "${OPERATOR_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-acm.log
+    oc get pods -n "${OPERATOR_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-mce.log
+    oc get pods -n "${DEPLOYMENT_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-mce.log
+    oc get csv -n "${OPERATOR_NAMESPACE}" > ${BASE_COLLECTION_PATH}/gather-mce.log
     oc adm inspect  ns/"${DEPLOYMENT_NAMESPACE}"  --dest-dir=must-gather
     oc adm inspect  ns/"${OPERATOR_NAMESPACE}"  --dest-dir=must-gather
     oc adm inspect  ns/open-cluster-management-hub  --dest-dir=must-gather
     # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
-    oc get proxy -o yaml > ${BASE_COLLECTION_PATH}/gather-proxy.log
+    oc get proxy -o yaml > ${BASE_COLLECTION_PATH}/gather-proxy-mce.log
     oc adm inspect  ns/hive  --dest-dir=must-gather
     oc adm inspect  multiclusterengines.multicluster.openshift.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect hiveconfigs.hive.openshift.io --all-namespaces  --dest-dir=must-gather
@@ -111,7 +111,6 @@ gather_hub() {
     oc adm inspect machinepools.hive.openshift.io --all-namespaces  --dest-dir=must-gather
 
 
-
     oc adm inspect  managedclusterviews.view.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  managedclusteractions.action.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  manifestworks.work.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
@@ -122,7 +121,6 @@ gather_hub() {
     oc adm inspect  managedclustersets.cluster.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  managedclustersetbindings.cluster.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
     oc adm inspect  managedclusterimageregistries.imageregistry.open-cluster-management.io --all-namespaces  --dest-dir=must-gather
-
 
 
     oc adm inspect validatingwebhookconfigurations.admissionregistration.k8s.io --all-namespaces --dest-dir=must-gather


### PR DESCRIPTION
issue: https://issues.redhat.com/browse/ACM-6005

I did not put the files in a different folder,  could get confusing when just doing the mce must-gather if it isn't the same as usual, just adding mce to the file names. This will need to be cherrypicked for 2.3 and 2.2 as well