### PR TITLE
MGMT-15578: Collect event logs and cluster logs from failed MCE clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,11 @@ FROM quay.io/openshift/origin-cli:4.7 as builder
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y tar rsync findutils gzip iproute util-linux \
+    && microdnf install -y tar rsync findutils gzip iproute util-linux wget \
     && microdnf clean all
+
+RUN wget https://github.com/mikefarah/yq/releases/download/v4.2.0/yq_linux_amd64 -O /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
 
 # Copy oc binary
 COPY --from=builder /usr/bin/oc /usr/bin/oc


### PR DESCRIPTION
This change introduces the capability to remove service and event logs for failed MCE agents.

Related Issue: https://issues.redhat.com/browse/MGMT-15578

Description of Changes:
We are adding an ability to the MCE gather to obtain logs and events from agentclusterinstall CR's that are marked as "failed" where these logs are available.

What resource is being added: | N/A

Is this a Hub or Managed cluster change?:
Hub Cluster | Managed Cluster | N/A

Notes: