### PR TITLE
Gather CRD when not using self management

### DIFF
--- a/collection-scripts/mce-gather.sh
+++ b/collection-scripts/mce-gather.sh
@@ -272,6 +272,7 @@ gather_hub() {
   oc adm inspect ns/open-cluster-management-hub --dest-dir=$BASE_COLLECTION_PATH
   # request from https://bugzilla.redhat.com/show_bug.cgi?id=1853485
   oc get proxy -o yaml >${BASE_COLLECTION_PATH}/gather-proxy-mce.log
+  oc adm inspect customresourcedefinition.apiextensions.k8s.io
   oc adm inspect ns/hive --dest-dir=$BASE_COLLECTION_PATH
   oc adm inspect multiclusterengines.multicluster.openshift.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH
   oc adm inspect internalenginecomponents.multicluster.openshift.io --all-namespaces --dest-dir=$BASE_COLLECTION_PATH


### PR DESCRIPTION
Signed-off-by: David Luong <dluong@redhat.com>

# Description

Add CRD to non self managed hubs

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Add CRD to non self managed hubs

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [X] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: 
/cc @dhaiducek  @dislbenn 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
