### PR TITLE
Restore `tar` prereq for hypershift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_amd6
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y rsync findutils \
+    && microdnf install -y rsync tar gzip findutils \
     && microdnf clean all
 
 # Copy binaries

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -9,7 +9,7 @@ RUN wget https://github.com/mikefarah/yq/releases/download/v4.44.2/yq_linux_amd6
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 RUN microdnf update -y \
-    && microdnf install -y rsync findutils \
+    && microdnf install -y rsync tar gzip findutils \
     && microdnf clean all
 
 # Copy binaries


### PR DESCRIPTION
Restores a prerequisite for running the Hypershift log dump.

ref: https://issues.redhat.com/browse/ACM-16255