### PR TITLE
Update ose-cli-rhel9 from v4.21 to v4.22

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Red Hat, Inc.
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.21 as builder
+FROM registry.redhat.io/openshift4/ose-cli-rhel9:v4.22 as builder
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
# Description

Update ose-cli-rhel9 builder image version in RHTAP Dockerfile to align with main Dockerfile.

## Related Issue

N/A - Maintenance update

## Changes Made

- Bumped `registry.redhat.io/openshift4/ose-cli-rhel9` from v4.21 to v4.22 in `build/Dockerfile.rhtap`
- Aligns RHTAP build with main Dockerfile which uses `origin-cli:4.22`

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

This is a version alignment update following the pattern of previous commit c673474.

## Reviewers

/cc 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.