### PR TITLE
fix: remove incorrect github.actor reference from stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,8 +21,8 @@ jobs:
     - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: '@${{ github.actor }} This issue has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
-        stale-pr-message: '@${{ github.actor }} This pull request has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        stale-issue-message: 'This issue has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
+        stale-pr-message: 'This pull request has been marked as stale due to inactivity for 5 days. It will be closed in 7 days if no further activity occurs.'
         close-issue-message: 'This issue was closed because it has been stale for 7 days with no activity.'
         close-pr-message: 'This pull request was closed because it has been stale for 7 days with no activity.'
         stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
## Summary
- Remove `@${{ github.actor }}` from stale issue and PR messages
- In scheduled workflows, `github.actor` resolves to the last committer on the default branch, not the issue/PR author
- GitHub already notifies subscribed users automatically, so the @-mention is unnecessary

/cc @cameronmwall @ngraham20

## Test plan
- [ ] Verify stale workflow YAML is valid
- [ ] Confirm messages no longer reference github.actor

🤖 Generated with [Claude Code](https://claude.com/claude-code)